### PR TITLE
iploc_be: correct goarch name

### DIFF
--- a/iploc_be.go
+++ b/iploc_be.go
@@ -1,4 +1,4 @@
-// +build ppc64be mipsbe mips64be mips64p32be
+// +build ppc64 mips mips64 mips64p32
 
 package iploc
 


### PR DESCRIPTION
Golang defaults to big endian and the `be` suffix is not used.
Reference: https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63